### PR TITLE
Apply clang tidy

### DIFF
--- a/build_scripts/check.sh
+++ b/build_scripts/check.sh
@@ -20,7 +20,7 @@ echo "cpp-check"
 cppcheck --std=c11 --platform=unix32 -q --error-exitcode=1 -DPLACE_IN_SECTION --language=c ./source
 
 echo "clang-tidy"
-run-clang-tidy -p $workdir/build/release -extra-arg="-DSTATIC_CODE_ANALYSIS 1" workdir/source/utility/scheduler/
+run-clang-tidy -p $workdir/build/release -extra-arg="-DSTATIC_CODE_ANALYSIS=1" -extra-arg="--std=gnu99" $workdir/source
 
 
 # spell checker

--- a/source/app/Presentation.c
+++ b/source/app/Presentation.c
@@ -395,7 +395,7 @@ static void HandleUnrecoverableError(uint32_t errorCode) {
   Screen_DisplayFourDigits(errorCode, rowBottom, Screen_DisplayMinusBottom);
   Screen_UpdatePendingRequests();
   LOG_ERROR("Unrecoverable error %lu!!\nThe system needs to be rebooted\n!",
-            errorCode);
+            (unsigned long)errorCode);
 }
 
 static void LogFirmwareVersion(void) {

--- a/source/app/SysTest.h
+++ b/source/app/SysTest.h
@@ -39,6 +39,7 @@
 #define SYS_TEST_H
 
 #include "hal/Uart.h"
+#include "utility/StaticCodeAnalysisHelper.h"
 #include "utility/scheduler/MessageBroker.h"
 
 /// Defines the actually available test groups
@@ -68,7 +69,7 @@ typedef struct _tSysTest_Message {
                                         ///< the specified test function.
 } SysTest_Message_t;
 
-static_assert(sizeof(SysTest_Message_t) <= sizeof(uint64_t));
+ASSERT_SIZE_TYPE1_LESS_THAN_TYPE2(SysTest_Message_t, uint64_t);
 
 /// Return an initialized instance to the system test controller
 /// @return Pointer to a message listener

--- a/source/app/System.c
+++ b/source/app/System.c
@@ -91,7 +91,7 @@ static void RunSystem(void);
 /// @param config data to start the message broker
 /// @param nrOfObservers nr of observers
 /// @param ... listeners that will register
-static void InitMessageBroker(MessageBus_t* config, uint8_t nrOfObservers, ...);
+static void InitMessageBroker(MessageBus_t* config, int nrOfObservers, ...);
 
 /// Task function to run the message broker in the scheduler
 static void RunAppMessageDispatch();
@@ -166,9 +166,7 @@ static void RunSystem(void) {
   }
 }
 
-static void InitMessageBroker(MessageBus_t* config,
-                              uint8_t nrOfObservers,
-                              ...) {
+static void InitMessageBroker(MessageBus_t* config, int nrOfObservers, ...) {
   MessageBroker_Create(&config->broker, config->messages,
                        COUNT_OF(config->messages), config->taskId,
                        config->priority);

--- a/source/app_service/networking/ble/BleGap.c
+++ b/source/app_service/networking/ble/BleGap.c
@@ -145,7 +145,7 @@ void BleGap_AdvertiseRequest(BleTypes_ApplicationContext_t* applicationContext,
   if ((applicationContext->deviceConnectionStatus ==
        BLE_INTERFACE_ADVERTISING) &&
       (applicationContext->currentAdvertisementMode.compare != mode.compare)) {
-    ret = aci_gap_set_non_discoverable();
+    aci_gap_set_non_discoverable();
     applicationContext->deviceConnectionStatus = BLE_INTERFACE_IDLE;
   }
 

--- a/source/app_service/networking/ble/BleGatt.c
+++ b/source/app_service/networking/ble/BleGatt.c
@@ -43,7 +43,7 @@ uint16_t BleGatt_AddPrimaryService(BleTypes_Uuid_t uuid,
       uuid.uuidType, (const Service_UUID_t*)&uuid.uuid, PRIMARY_SERVICE,
       nrOfCharacteristics * 2 + 1, &serviceHandle);
 
-  if (!status == BLE_STATUS_SUCCESS) {
+  if (status != BLE_STATUS_SUCCESS) {
     return 0;
   }
   return serviceHandle;

--- a/source/app_service/networking/ble/BleHelper.c
+++ b/source/app_service/networking/ble/BleHelper.c
@@ -45,7 +45,7 @@ static char gBleStringFormatBuffer[256];
 
 const char* BleHelper_FormatCallStatus(const char* call, uint32_t status) {
   snprintf(gBleStringFormatBuffer, sizeof gBleStringFormatBuffer,
-           "%s returned with code 0x%04lx\n", call, status);
+           "%s returned with code 0x%04lx\n", call, (unsigned long)status);
   return gBleStringFormatBuffer;
 }
 

--- a/source/app_service/networking/ble/BleInterface.h
+++ b/source/app_service/networking/ble/BleInterface.h
@@ -41,6 +41,7 @@
 #define BLEINTERFACE_H
 
 #include "BleTypes.h"
+#include "utility/StaticCodeAnalysisHelper.h"
 #include "utility/scheduler/Message.h"
 
 #include <stdint.h>
@@ -63,7 +64,7 @@ typedef struct _tBleInterface_Message {
   } parameter;              ///< message parameter
 } BleInterface_Message_t;
 
-static_assert(sizeof(Message_Message_t) == sizeof(uint64_t));
+ASSERT_SIZE_TYPE1_LESS_THAN_TYPE2(Message_Message_t, uint64_t);
 
 /// Startup the Bluetooth Low Energy interface
 /// @param appContext Ble application context.

--- a/source/app_service/networking/ble/BleOverrides.c
+++ b/source/app_service/networking/ble/BleOverrides.c
@@ -55,14 +55,14 @@
 ///  - hci_resume_flow()
 ///
 /// @param data Packet or event pointer
-void hci_notify_asynch_evt(void* data) {  // NOLINT
+void hci_notify_asynch_evt(void* data) {
   UTIL_SEQ_SetTask(1 << SCHEDULER_TASK_HANDLE_HCI_EVENT, SCHEDULER_PRIO_0);
 }
 
 /// Signals an event to the task that handles asynchronous events from CPU1.
 ///
 /// @param flag: Release flag
-void hci_cmd_resp_release(uint32_t flag) {  // NOLINT
+void hci_cmd_resp_release(uint32_t flag) {
   UTIL_SEQ_SetEvt(1 << SCHEDULER_EVENT_HCI_CMD_RESPONSE);
 }
 
@@ -70,6 +70,6 @@ void hci_cmd_resp_release(uint32_t flag) {  // NOLINT
 /// (triggered by hci_cmd_resp_release)
 ///
 /// @param timeout: Waiting timeout
-void hci_cmd_resp_wait(uint32_t timeout) {  // NOLINT
+void hci_cmd_resp_wait(uint32_t timeout) {
   UTIL_SEQ_WaitEvt(1 << SCHEDULER_EVENT_HCI_CMD_RESPONSE);
 }

--- a/source/app_service/networking/ble/gatt_service/DeviceInfo.c
+++ b/source/app_service/networking/ble/gatt_service/DeviceInfo.c
@@ -172,7 +172,7 @@ static void AddSerialNumberCharacteristic(struct _tService* service) {
       .encryptionKeySize = 10,
       .isVariableLengthValue = true};
 
-  snprintf((char*)buffer, sizeof(buffer), "%lx", deviceId);
+  snprintf((char*)buffer, sizeof(buffer), "%lx", (unsigned long)deviceId);
   service->serialNumberHandle =
       BleGatt_AddCharacteristic(service->serviceHandle, &characteristic, buffer,
                                 strnlen((char*)buffer, sizeof(buffer)));

--- a/source/app_service/power_manager/BatteryMonitor.h
+++ b/source/app_service/power_manager/BatteryMonitor.h
@@ -35,6 +35,7 @@
 #ifndef BATTERY_MONITOR_H
 #define BATTERY_MONITOR_H
 
+#include "utility/StaticCodeAnalysisHelper.h"
 #include "utility/scheduler/Message.h"
 #include "utility/scheduler/MessageListener.h"
 
@@ -55,7 +56,7 @@ typedef struct tBatteryMonitor_Message {
   BatteryMonitor_AppState_t previousState;  ///< previous application state
 } BatteryMonitor_Message_t;
 
-static_assert(sizeof(Message_Message_t) == sizeof(uint64_t));
+ASSERT_SIZE_TYPE1_LESS_THAN_TYPE2(Message_Message_t, uint64_t);
 
 /// specifies the message id's of this category
 typedef enum {

--- a/source/app_service/sensor/Sht4x.h
+++ b/source/app_service/sensor/Sht4x.h
@@ -39,6 +39,7 @@
 #define SHT4X_H
 
 #include "assert.h"
+#include "utility/StaticCodeAnalysisHelper.h"
 #include "utility/scheduler/MessageBroker.h"
 
 /// These are the ids of the message category
@@ -80,7 +81,7 @@ typedef struct _tSht4x_SensorMessage {
            ///<      message contains the measurement data or the serial number
 } Sht4x_SensorMessage_t;
 
-static_assert(sizeof(Sht4x_SensorMessage_t) == 8);
+ASSERT_SIZE_TYPE1_LESS_THAN_TYPE2(Sht4x_SensorMessage_t, uint64_t);
 
 /// Initialize the SHT4x Sensor
 ///

--- a/source/utility/collection/LinkedList.c
+++ b/source/utility/collection/LinkedList.c
@@ -103,12 +103,11 @@ bool LinkedList_Remove(LinkedList_List_t* list, LinkedList_Node_t* node) {
 
 void LinkedList_Empty(LinkedList_List_t* list) {
   LinkedList_Node_t* current = &list->head;
-  LinkedList_Node_t* previous = current;
   uint32_t priorityMask = Concurrency_EnterCriticalSection();
 
   // reset all link information
   while (current->next != &list->head) {
-    previous = current;
+    LinkedList_Node_t* previous = current;
     current = current->next;
     previous->next = 0;
   }


### PR DESCRIPTION
All the code in folder source is checked with clang-tidy. These issues
have been found and corrected:
- explicit cast to unsigned long required when using long format
  specifier
- static_cast must not be used
- last argument of va-args must not use standard promotion.
- clang-tidy must be called with compiler option --std=gnu99 since
  arm-none-eabi does not fully support c11.