### PR TITLE
Support additional parameter for error message

### DIFF
--- a/source/app/System.c
+++ b/source/app/System.c
@@ -226,11 +226,17 @@ void ErrorHandler_UnrecoverableError(ErrorHandler_ErrorCode_t code) {
 }
 
 void ErrorHandler_RecoverableError(ErrorHandler_ErrorCode_t code) {
+  ErrorHandler_RecoverableErrorExtended(code, 0);
+}
+
+void ErrorHandler_RecoverableErrorExtended(ErrorHandler_ErrorCode_t code,
+                                           uint8_t param) {
   // The recoverable error is sent in another category to allow faster filtering
   // and since it does not trigger a state change
   Message_Message_t msg = {
       .header.id = 1,
       .header.category = MESSAGE_BROKER_CATEGORY_RECOVERABLE_ERROR,
+      .header.parameter1 = param,
       .parameter2 = code};
   Message_PublishAppMessage((Message_Message_t*)&msg);
 }

--- a/source/utility/ErrorHandler.h
+++ b/source/utility/ErrorHandler.h
@@ -40,6 +40,8 @@
 #ifndef __ERROR_HANDLER_H
 #define __ERROR_HANDLER_H
 
+#include <stdint.h>
+
 /// Macro to assert a condition
 #define ASSERT(x)                                               \
   do {                                                          \
@@ -76,5 +78,14 @@ void ErrorHandler_UnrecoverableError(ErrorHandler_ErrorCode_t code);
 /// On application layer it will be ignored.
 /// @param code Error code that is published
 void ErrorHandler_RecoverableError(ErrorHandler_ErrorCode_t code);
+
+/// Signals a recoverable error with an additional parameter
+///
+/// A recoverable error may be used to exit a wait state of a state machine
+/// On application layer it will be ignored.
+/// @param code Error code that is published
+/// @param parameter Parameter that can be used to resolve the error condition
+void ErrorHandler_RecoverableErrorExtended(ErrorHandler_ErrorCode_t code,
+                                           uint8_t parameter);
 
 #endif  // __ERROR_HANDLER_H


### PR DESCRIPTION
In some cases it is usful to provide an additional parameter with the error code to support the resolution of the error. This will be used in the item store. It will allow to notify the page that shows inconsitencies and that should be erased.