### PR TITLE
Fix uuid of ble characteristics

### DIFF
--- a/source/app_service/networking/ble/BleGatt.c
+++ b/source/app_service/networking/ble/BleGatt.c
@@ -83,3 +83,13 @@ tBleStatus BleGatt_UpdateCharacteristic(uint16_t serviceHandle,
 
   return status;
 }
+
+/// Build characteristic uuid from a service uuid and a 16-bit characteristic
+/// id.
+void BleGatt_ExtendCharacteristicUuid(BleTypes_Uuid_t* characteristicId,
+                                      BleTypes_Uuid_t* serviceId) {
+  uint16_t id = characteristicId->uuid.Char_UUID_16;
+  memcpy(characteristicId, serviceId, sizeof(BleTypes_Uuid_t));
+  characteristicId->uuid.Char_UUID_128[13] = (id >> 8) & 0xFF;
+  characteristicId->uuid.Char_UUID_128[12] = id & 0xFF;
+}

--- a/source/app_service/networking/ble/BleGatt.h
+++ b/source/app_service/networking/ble/BleGatt.h
@@ -37,6 +37,15 @@
 
 #include "app_service/networking/ble/BleTypes.h"
 
+/// Build characteristic uuid from a service uuid and a 16-bit characteristic
+/// id.
+/// @param characteristicId Pointer to the characteristic id; The 16bit id is
+///                         assumed to be set
+/// @param serviceId Pointer to the service id, the characteristic uuid is
+///                  extended from.
+void BleGatt_ExtendCharacteristicUuid(BleTypes_Uuid_t* characteristicId,
+                                      BleTypes_Uuid_t* serviceId);
+
 /// Add a gatt service with specified uuid and a max number of characteristics
 ///
 /// This method service as facade to the function aci_gatt_add_service()

--- a/source/app_service/networking/ble/gatt_service/HumidityService.c
+++ b/source/app_service/networking/ble/gatt_service/HumidityService.c
@@ -85,14 +85,15 @@ void HumidityService_SetHumidity(float humidity) {
 
 static void AddHumidityCharacteristic(struct _tService* service) {
   BleTypes_Characteristic_t humidityCharacteristic = {
-      .uuid.uuidType = BLE_TYPES_UUID16,
-      .uuid.uuid.Char_UUID_16 = 1235,
+      .uuid.uuid.Char_UUID_16 = 0x1235,
       .maxValueLength = 4,
       .characteristicPropertyFlags = CHAR_PROP_READ | CHAR_PROP_NOTIFY,
       .securityFlags = ATTR_PERMISSION_NONE,
       .eventFlags = GATT_DONT_NOTIFY_EVENTS,
       .encryptionKeySize = 10,
       .isVariableLengthValue = false};
+  BleGatt_ExtendCharacteristicUuid(&humidityCharacteristic.uuid,
+                                   &_humidityServiceId);
 
   // set initial humidity
   float initialHumidity = NAN;

--- a/source/app_service/networking/ble/gatt_service/ShtService.c
+++ b/source/app_service/networking/ble/gatt_service/ShtService.c
@@ -80,14 +80,15 @@ void ShtService_SetSerialNumber(uint32_t serialNumber) {
 
 static void AddSerialNumberCharacteristic(struct _tService* service) {
   BleTypes_Characteristic_t serialNumberCharacteristic = {
-      .uuid.uuidType = BLE_TYPES_UUID16,
-      .uuid.uuid.Char_UUID_16 = 6001,
+      .uuid.uuid.Char_UUID_16 = 0x6001,
       .maxValueLength = 4,
       .characteristicPropertyFlags = CHAR_PROP_READ,
       .securityFlags = ATTR_PERMISSION_NONE,
       .eventFlags = GATT_DONT_NOTIFY_EVENTS,
       .encryptionKeySize = 10,
       .isVariableLengthValue = false};
+  BleGatt_ExtendCharacteristicUuid(&serialNumberCharacteristic.uuid,
+                                   &_sthServiceId);
 
   // set initial serial number
   uint32_t serialNumberInit = 0;

--- a/source/app_service/networking/ble/gatt_service/TemperatureService.c
+++ b/source/app_service/networking/ble/gatt_service/TemperatureService.c
@@ -86,13 +86,15 @@ void TemperatureService_SetTemperature(float temperature) {
 static void AddTemperatureCharacteristic(struct _tService* service) {
   BleTypes_Characteristic_t temperatureCharacteristic = {
       .uuid.uuidType = BLE_TYPES_UUID16,
-      .uuid.uuid.Char_UUID_16 = 2235,
+      .uuid.uuid.Char_UUID_16 = 0x2235,
       .maxValueLength = 4,
       .characteristicPropertyFlags = CHAR_PROP_READ | CHAR_PROP_NOTIFY,
       .securityFlags = ATTR_PERMISSION_NONE,
       .eventFlags = GATT_DONT_NOTIFY_EVENTS,
       .encryptionKeySize = 10,
       .isVariableLengthValue = false};
+  BleGatt_ExtendCharacteristicUuid(&temperatureCharacteristic.uuid,
+                                   &_temperatureServiceId);
 
   // set initial serial temperature
   float initialTemperature = NAN;


### PR DESCRIPTION
Custom ble characteristics need to have a uuid of 128 bit. The framework does not extend these uuid's automatically.
Therefore a helper method is introduced that does this extension. The errornous uuid's have now been fixed.