### PR TITLE
Add feature to delete all items of an item store

### DIFF
--- a/source/app/SysTest.c
+++ b/source/app/SysTest.c
@@ -103,7 +103,7 @@ static SysTest_TestFunctionCb_t _flashTestFunctions[] = {
 /// Test functions to test the LCD screen
 static SysTest_TestFunctionCb_t _itemStoreTestFunctions[] = {
     ItemStoreTest_AddItem, ItemStoreTest_TimerAddItem,
-    ItemStoreTest_EnumerateItems};
+    ItemStoreTest_EnumerateItems, ItemStoreTest_DeleteAllItems};
 
 /// Array with test function pointers
 static SysTest_TestFunctionCb_t* _allTests[] = {

--- a/source/app/test/FlashTest.c
+++ b/source/app/test/FlashTest.c
@@ -55,7 +55,9 @@ static uint8_t _testBuffer[32];
 
 /// Callback to indicate the completion of the erase operation
 /// @param pageId the page id that was erased.
-static void EraseDoneCallback(uint32_t pageId);
+/// @param remaining number of pages that have not been erased
+///                  on a successful operation this should be 0.
+static void EraseDoneCallback(uint32_t pageId, uint8_t remaining);
 
 void FlashTest_Erase(SysTest_TestMessageParameter_t param) {
   Flash_Erase(FLASH_TEST_PAGE_0 + param.byteParameter[0],
@@ -84,6 +86,7 @@ void FlashTest_Write(SysTest_TestMessageParameter_t param) {
   Uart_WriteBlocking(_testBuffer, nrOfBytes);
 }
 
-static void EraseDoneCallback(uint32_t pageId) {
+static void EraseDoneCallback(uint32_t pageId, uint8_t remaining) {
+  UNUSED(remaining);
   LOG_INFO("Erase done %li", pageId);
 }

--- a/source/app/test/ItemStoreTest.c
+++ b/source/app/test/ItemStoreTest.c
@@ -100,6 +100,10 @@ void ItemStoreTest_EnumerateItems(SysTest_TestMessageParameter_t param) {
   ItemStore_BeginEnumerate(param.byteParameter[0], &_enumerator, callback);
 }
 
+void ItemStoreTest_DeleteAllItems(SysTest_TestMessageParameter_t param) {
+  ItemStore_DeleteAllItems(param.byteParameter[0]);
+}
+
 static void OnTimerElapsed() {
   if (_timerAddItemParameter.shortParameter[1] == 0) {
     TimerServer_Stop(_timerAddItemId);

--- a/source/app/test/ItemStoreTest.h
+++ b/source/app/test/ItemStoreTest.h
@@ -42,7 +42,8 @@
 typedef enum {
   FUNCTION_ID_ADD_ITEM = 0,
   FUNCTION_ID_ADD_ITEMS_FROM_TIMER = 1,
-  FUNCTION_ID_ENUMERATE_ITEMS = 2
+  FUNCTION_ID_ENUMERATE_ITEMS = 2,
+  FUNCTION_ID_DELETE_ALL_ITEMS = 3
 } ItemStore_FunctionId_t;
 
 /// Add an item to the item store
@@ -59,7 +60,7 @@ void ItemStoreTest_AddItem(SysTest_TestMessageParameter_t param);
 ///              shortParameter[1] is the number of items that shall be inserted
 void ItemStoreTest_TimerAddItem(SysTest_TestMessageParameter_t param);
 
-/// Enumerate the
+/// Enumerate the item store items
 /// @param param parameters of the EnumerateItems function
 ///              byteParameter[0] is the item to be added;
 ///              byteParameter[1] selects the semantics of next parameter
@@ -67,5 +68,10 @@ void ItemStoreTest_TimerAddItem(SysTest_TestMessageParameter_t param);
 ///                 * 0 => number of items to be read from index 0
 ///                 * 1 => items from start index until end of enumeration
 void ItemStoreTest_EnumerateItems(SysTest_TestMessageParameter_t param);
+
+/// Delete all entries from an item store
+/// @param param parameters of the DeleteAllItems function
+///              byteParameter[0] is the item store id to be emptied;
+void ItemStoreTest_DeleteAllItems(SysTest_TestMessageParameter_t param);
 
 #endif  // ITEM_STORE_TEST_H

--- a/source/app_service/item_store/ItemStore.h
+++ b/source/app_service/item_store/ItemStore.h
@@ -35,6 +35,7 @@
 #ifndef ITEM_STORE_H
 #define ITEM_STORE_H
 
+#include "utility/StaticCodeAnalysisHelper.h"
 #include "utility/scheduler/MessageListener.h"
 
 #include <stdbool.h>
@@ -113,6 +114,17 @@ typedef struct _tItemStore_Enumerator {
 /// @return Message listener that handles massages for the item stores
 MessageListener_Listener_t* ItemStore_ListenerInstance();
 
+/// Parameter of an erase message
+typedef struct {
+  ItemStore_ItemDef_t itemStore;  ///< Item store on which the erase takes place
+  bool reinit;                    ///< Flag if initialization is required
+                                  ///< after erase.
+  uint8_t pageNumber;             ///< Number of page where the erase starts
+  uint8_t nrOfPages;              ///< Number of pages to erase
+} ItemStore_EraseParameters_t;
+
+ASSERT_SIZE_TYPE1_LESS_THAN_TYPE2(ItemStore_EraseParameters_t, uint32_t);
+
 /// Initialize the item store upon reset.
 ///
 /// The ItemStore_listenerInstance() has to be registered prior to calling ItemStore_Init()
@@ -124,6 +136,11 @@ void ItemStore_Init();
 /// @param data The data to be added to the item store
 void ItemStore_AddItem(ItemStore_ItemDef_t item,
                        const ItemStore_ItemStruct_t* data);
+
+/// Delete all items in the specified item store
+/// All pages that belong to this item store will be erased
+/// @param item Id of the item store
+void ItemStore_DeleteAllItems(ItemStore_ItemDef_t item);
 
 /// Initialize an object to enumerate all items that are stored
 /// in the specified item store. This operation is called asynchronously in

--- a/source/app_service/item_store/MeasurementItemController.c
+++ b/source/app_service/item_store/MeasurementItemController.c
@@ -35,6 +35,7 @@
 #include "MeasurementItemController.h"
 
 #include "ItemStore.h"
+#include "app_service/networking/ble/BleGatt.h"
 #include "app_service/sensor/Sht4x.h"
 #include "utility/scheduler/MessageId.h"
 
@@ -71,8 +72,8 @@ typedef struct _tMeasurementItemController {
 static bool ItemStoreIdleState(Message_Message_t* message);
 
 /// Update the moving average for humidity and temperature
-/// @param msg message to be processed
-static void UpdateMovingAverage(Sht4x_SensorMessage_t* msg);
+/// @param message message to be processed
+static void UpdateMovingAverage(Sht4x_SensorMessage_t* message);
 
 /// Update the sample value if a full logging interval has elapsed
 /// @param msg The message with the amount of elapsed seconds
@@ -94,7 +95,8 @@ MeasurementItemController_t _measurementItemController = {
     .listener.currentMessageHandlerCb = ItemStoreIdleState,
     .listener.receiveMask = MESSAGE_BROKER_CATEGORY_ITEM_STORE |
                             MESSAGE_BROKER_CATEGORY_SENSOR_VALUE |
-                            MESSAGE_BROKER_CATEGORY_TIME_INFORMATION};
+                            MESSAGE_BROKER_CATEGORY_TIME_INFORMATION |
+                            MESSAGE_BROKER_CATEGORY_BLE_SERVICE_REQUEST};
 
 MessageListener_Listener_t* MeasurementItemController_Instance() {
   return &_measurementItemController.listener;

--- a/source/hal/Flash.c
+++ b/source/hal/Flash.c
@@ -35,16 +35,68 @@
 #include "Flash.h"
 
 #include "hal/IrqPrio.h"
+#include "hw_conf.h"
+#include "shci.h"
 #include "stm32_lpm.h"
+#include "stm32_seq.h"
 #include "stm32wbxx_hal.h"
+#include "stm32wbxx_ll_hsem.h"
 #include "utility/AppDefines.h"
 #include "utility/ErrorHandler.h"
+#include "utility/concurrency/Concurrency.h"
+#include "utility/scheduler/MessageBroker.h"
+#include "utility/scheduler/Scheduler.h"
 
 #include <stdint.h>
 #include <string.h>
 
 /// helper macro to compute minimum; only used internally!
+#ifndef MIN
 #define MIN(x, y) (x) > (y) ? (y) : (x)
+#endif
+
+/// the one and only category of this message domain
+#define FLASH_MSG_CATEGORY 0x1
+/// Number of messages in the message queue of the FlashTask message dispatcher.
+#define NR_OF_FLASH_MESSAGES 0x4
+
+/// Messages that may occur while erasing multiple pages.
+typedef enum {
+  FLASH_MESSAGE_PROCESS_NEXT_PAGE,
+} FlashMessageId_t;
+
+/// message handler of the flash task
+static MessageBroker_Broker_t _flashMessageDispatcher;
+
+/// queue to hold the messages
+static uint64_t _flash_task_messages[NR_OF_FLASH_MESSAGES];
+
+/// Function that handles the incoming flash messages in the FlashTask
+/// @param msg Message to be handled
+/// @return True if the message is handled, false otherwise.
+static bool FlashMessageHandlerCb(Message_Message_t* msg);
+
+/// handler for flash messages
+static MessageListener_Listener_t _flashMessageHandler = {
+    .receiveMask = FLASH_MSG_CATEGORY,
+    .currentMessageHandlerCb = FlashMessageHandlerCb};
+
+/// Process the messages of the _flashMessageDispatcher
+static void FlashTask();
+
+/// Trigger the erase of a specific page
+/// @param pageNr Page that needs to be erased
+static void TriggerNextStart(uint8_t pageNr);
+
+/// Start the erase procedure
+/// The erase will be executed in the flash task. It will wait until the flash
+/// is accessible.
+/// Erasing a single page takes about 20ms.
+/// @param pageNr Start the erase of  a single page
+static void StartErase(uint8_t pageNr);
+
+/// Wait until the flash is ready for another program or erase operation
+static void awaitFlashAccessible();
 
 /// Function pointer that is used hold the callback to notify the
 /// client that the flash operation is complete.
@@ -53,10 +105,20 @@ static Flash_OperationComplete _flashOperationComplete;
 /// Memory structure that holds the erase parameters
 static FLASH_EraseInitTypeDef _eraseStruct;
 
+/// Number of pages to erase
+static uint16_t _pagesToErase;
+
 void Flash_Init() {
   __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_OPTVERR);
   HAL_NVIC_SetPriority(FLASH_IRQn, IRQ_PRIO_APP, 0);
-  HAL_NVIC_EnableIRQ(FLASH_IRQn);
+
+  // initialize and register flash FSM
+  MessageBroker_Create(&_flashMessageDispatcher, _flash_task_messages,
+                       NR_OF_FLASH_MESSAGES,
+                       SCHEDULER_TASK_HANDLE_FLASH_OPERATION, SCHEDULER_PRIO_3);
+  MessageBroker_RegisterListener(&_flashMessageDispatcher,
+                                 &_flashMessageHandler);
+  UTIL_SEQ_RegTask(_flashMessageDispatcher.taskBitmap, UTIL_SEQ_RFU, FlashTask);
 }
 
 bool Flash_Read(uint32_t address, uint8_t* buffer, uint16_t nrOfBytes) {
@@ -82,7 +144,10 @@ bool Flash_Write(uint32_t address, const uint8_t* buffer, uint16_t nrOfBytes) {
   }
   uint32_t writeAddress = address;
   uint16_t bytesWritten = 0;
-  HAL_FLASH_Unlock();
+
+  // reserve flash accesses for CPU1
+  while (LL_HSEM_1StepLock(HSEM, CFG_HW_FLASH_SEMID))
+    ;
   do {
     uint64_t data = *((uint64_t*)buffer);
     bytesWritten += sizeof(uint64_t);
@@ -93,40 +158,112 @@ bool Flash_Write(uint32_t address, const uint8_t* buffer, uint16_t nrOfBytes) {
       uint64_t mask = (0x1ULL << (8 * (bytesWritten - nrOfBytes))) - 1;
       data &= ~mask;  // clear the data that is not in buffer;
     }
-    if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, writeAddress, data) !=
-        HAL_OK) {
-      HAL_FLASH_Lock();
+    awaitFlashAccessible();
+    HAL_FLASH_Unlock();
+    HAL_StatusTypeDef status =
+        HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, writeAddress, data);
+    HAL_FLASH_Lock();
+    if (status != HAL_OK) {
+      LL_HSEM_ReleaseLock(HSEM, CFG_HW_FLASH_SEMID, 0);
       return false;
     }
     writeAddress += sizeof(uint64_t);
     buffer += sizeof(uint64_t);
   } while (bytesWritten < nrOfBytes);
-  HAL_FLASH_Lock();
+  LL_HSEM_ReleaseLock(HSEM, CFG_HW_FLASH_SEMID, 0);
   return true;
 }
 
 // start the erase procedure
+//
+// It it not allowed to erase more than one page in a row since this
+// would take to long and it would interfere with the radio timing.
+// Furthermore it is required to give CPU2 the chance to allow erase operation
+// only when at least 25ms no radio activity is done.
+// This timing protection is done using the program-erase suspend bits.
 void Flash_Erase(uint16_t startPageNr,
                  uint8_t nrOfPages,
                  Flash_OperationComplete callback) {
   ASSERT(_flashOperationComplete == 0);
-  UTIL_LPM_SetStopMode(1 << APP_DEFINE_LPM_CLIENT_FLASH, UTIL_LPM_DISABLE);
+  _pagesToErase = nrOfPages;
   _flashOperationComplete = callback;
+
+  // reserve flash accesses for CPU1
+  while (LL_HSEM_1StepLock(HSEM, CFG_HW_FLASH_SEMID))
+    ;
+
+  // prevent enter stop mode
+  UTIL_LPM_SetStopMode(1 << APP_DEFINE_LPM_CLIENT_FLASH, UTIL_LPM_DISABLE);
+
+  // enable the irq before starting the erase operation
+  NVIC_EnableIRQ(FLASH_IRQn);
+
+  // notify cpu2 about erase activity that may start
+  SHCI_C2_FLASH_EraseActivity(ERASE_ACTIVITY_ON);
+  TriggerNextStart(startPageNr);
+}
+
+// this operation is always called from within the FlashTask
+static void StartErase(uint8_t pageNr) {
   _eraseStruct.TypeErase = FLASH_TYPEERASE_PAGES;
-  _eraseStruct.Page = startPageNr;
-  _eraseStruct.NbPages = nrOfPages;
+  _eraseStruct.Page = pageNr;
+  _eraseStruct.NbPages = 1;
+
+  // make sure that no operation is suspended
+  awaitFlashAccessible();
+
   HAL_FLASH_Unlock();  // without unlocking, nothing happens, even no error!
+  // trigger the erase operation and wait for interrupt
   HAL_FLASHEx_Erase_IT(&_eraseStruct);
-  HAL_FLASH_Lock();
+}
+
+static bool FlashMessageHandlerCb(Message_Message_t* msg) {
+  if (msg->header.id == FLASH_MESSAGE_PROCESS_NEXT_PAGE) {
+    // start the erase of a next flash page
+    StartErase(msg->header.parameter1);
+    return true;
+  }
+  return false;
+}
+
+static void awaitFlashAccessible() {
+  while (LL_FLASH_IsActiveFlag_OperationSuspended())
+    ;
+}
+
+static void FlashTask() {
+  MessageBroker_Run(&_flashMessageDispatcher);
+}
+
+static void TriggerNextStart(uint8_t pageNr) {
+  Message_Message_t msg = {.header.category = FLASH_MSG_CATEGORY,
+                           msg.header.id = FLASH_MESSAGE_PROCESS_NEXT_PAGE};
+  msg.header.parameter1 = pageNr;
+  MessageBroker_PublishMessage(&_flashMessageDispatcher, &msg);
 }
 
 /// Called by interrupt handler when operation is finished.
 /// This function is called when an erase operation completes.
 /// @param parameter write address or page number;
 void HAL_FLASH_EndOfOperationCallback(uint32_t parameter) {
-  UTIL_LPM_SetStopMode(1 << APP_DEFINE_LPM_CLIENT_FLASH, UTIL_LPM_ENABLE);
-  _flashOperationComplete(parameter);
-  _flashOperationComplete = 0;
+  _pagesToErase--;
+  HAL_FLASH_Lock();
+  if (_pagesToErase == 0) {
+    UTIL_LPM_SetStopMode(1 << APP_DEFINE_LPM_CLIENT_FLASH, UTIL_LPM_ENABLE);
+    _flashOperationComplete(parameter, _pagesToErase);
+    _flashOperationComplete = 0;
+
+    // erase activity done
+    SHCI_C2_FLASH_EraseActivity(ERASE_ACTIVITY_OFF);
+
+    // Disable the interrupt after page erase
+    NVIC_DisableIRQ(FLASH_IRQn);
+
+    // release global flash semaphore
+    LL_HSEM_ReleaseLock(HSEM, CFG_HW_FLASH_SEMID, 0);
+    return;
+  }
+  TriggerNextStart(parameter + 1);
 }
 
 /// Called by interrupt handler when an error occurs.
@@ -134,8 +271,16 @@ void HAL_FLASH_EndOfOperationCallback(uint32_t parameter) {
 /// @param parameter
 void HAL_FLASH_OperationErrorCallback(uint32_t parameter) {
   UTIL_LPM_SetStopMode(1 << APP_DEFINE_LPM_CLIENT_FLASH, UTIL_LPM_ENABLE);
-  _flashOperationComplete(-1);
+  _flashOperationComplete(parameter, _pagesToErase);
   _flashOperationComplete = 0;
+
+  // erase activity done
+  SHCI_C2_FLASH_EraseActivity(ERASE_ACTIVITY_OFF);
+
+  HAL_FLASH_Lock();
+
+  // release semaphore
+  LL_HSEM_ReleaseLock(HSEM, CFG_HW_FLASH_SEMID, 0);
 }
 
 /// Flash Irq handler

--- a/source/utility/scheduler/Scheduler.h
+++ b/source/utility/scheduler/Scheduler.h
@@ -54,8 +54,8 @@ typedef enum {
   SCHEDULER_FIRST_NO_HCICMD_TASK =
       SCHEDULER_LAST_HCICMD_TASK - 1,  //first enum item
   SCHEDULER_TASK_HANDLE_SYSTEM_HCI_EVENT,
+  SCHEDULER_TASK_HANDLE_FLASH_OPERATION,
   SCHEDULER_TASK_HANDLE_APP_MESSAGES,
-  SCHEDULER_TASK_HANDLE_SYSTEM_TEST_EVENT,
   SCHEDULER_LAST_NO_HCI_CMD_TASK  // this is the last id of the enum
 } Scheduler_NoHciCmdTaskId_t;
 
@@ -65,6 +65,7 @@ typedef enum {
   SCHEDULER_PRIO_0,
   SCHEDULER_PRIO_1,
   SCHEDULER_PRIO_2,
+  SCHEDULER_PRIO_3,
 } Scheduler_SchedulerPriority_t;
 
 /// This enum describes the list sequencer events
@@ -74,7 +75,7 @@ typedef enum {
 typedef enum {
   SCHEDULER_EVENT_HCI_CMD_RESPONSE,
   SCHEDULER_EVENT_SYSTEM_HCI_CMD_RESPONSE,
-  SCHEDULER_EVENT_FLASH_OP_COMPLETE,
+  SCHEDULER_EVENT_FLASH_OP_COMPLETE
 } Scheduler_SequencerEvent_t;
 
 #endif  // SCHEDULER_H


### PR DESCRIPTION
When changing the logging interval, all stored measurement items need to be removed.
The implementation of this feature required a change in the implementation of the flash erase operation.