### PR TITLE
Provide one COUNT_OF macro

### DIFF
--- a/source/app/SysTest.c
+++ b/source/app/SysTest.c
@@ -45,14 +45,12 @@
 #include "test/QspiTest.h"
 #include "test/ScreenTest.h"
 #include "test/TraceTest.h"
+#include "utility/AppDefines.h"
 #include "utility/ErrorHandler.h"
 #include "utility/log/Log.h"
 
 #include <memory.h>
 #include <stdint.h>
-
-/// Count the number of elements in an array
-#define COUNT_OF(x) (sizeof(x) / sizeof(x)[0])
 
 /// Offset of the parameter within the 6 bytes received from the uart receiver
 #define MSG_PARAM_OFFSET 2

--- a/source/app/System.c
+++ b/source/app/System.c
@@ -66,15 +66,13 @@
 #include "stdarg.h"
 #include "stm32_lpm.h"
 #include "stm32_seq.h"
+#include "utility/AppDefines.h"
 #include "utility/ErrorHandler.h"
 #include "utility/log/Log.h"
 #include "utility/log/Trace.h"
 #include "utility/scheduler/MessageBroker.h"
 #include "utility/scheduler/MessageId.h"
 #include "utility/scheduler/Scheduler.h"
-
-/// count number of elements in an array
-#define COUNT_OF(x) (sizeof(x) / sizeof(x)[0])
 
 /// Type definition for the message broker initialization
 typedef struct _tMessageBus {

--- a/source/app_service/item_store/ItemStore.c
+++ b/source/app_service/item_store/ItemStore.c
@@ -37,6 +37,7 @@
 #include "hal/Flash.h"
 #include "stm32wbxx_hal.h"
 #include "stm32wbxx_hal_flash.h"
+#include "utility/AppDefines.h"
 #include "utility/ErrorHandler.h"
 #include "utility/scheduler/Message.h"
 #include "utility/scheduler/MessageListener.h"
@@ -56,9 +57,6 @@
 
 /// Compute the flash address from a page number
 #define PAGE_ADDR(x) ((x)*FLASH_PAGE_SIZE) + FLASH_BASE
-
-/// Get the number of element within an array
-#define COUNT_OF(arr) sizeof((arr)) / sizeof((arr)[0])
 
 /// Upper bound for pageBlock indices
 #define MAX_BLOCK_INDEX 32

--- a/source/utility/AppDefines.h
+++ b/source/utility/AppDefines.h
@@ -79,6 +79,9 @@
 /// The values are defined in AN5270.pdf
 #define BLE_TX_POWER 0x19
 
+/// Count the number of elements in an array
+#define COUNT_OF(arr) (sizeof(arr) / sizeof((arr)[0]))
+
 /// Defines the application components that may prevent the low power manager
 /// to enter a specific power down mode.
 typedef enum {


### PR DESCRIPTION
The COUNT_OF is used in many places. Instead of having a separate implementation in each .c file we have now one single definition.