### PR TITLE
Fix function ItemStore_GetNext(..)

### DIFF
--- a/source/app_service/item_store/ItemStore.c
+++ b/source/app_service/item_store/ItemStore.c
@@ -514,6 +514,7 @@ bool ItemStore_GetNext(ItemStore_Enumerator_t* enumerator,
   }
 
   uint32_t readAddress = PAGE_ADDR(status->enumeratingPage.beginTag.pageId) +
+                         +sizeof(PageHeader_t) +
                          status->currentIndex * itemStoreInfo->itemSize;
   if (!Flash_Read(readAddress, (uint8_t*)data,
                   status->enumeratingPage.beginTag.itemSize)) {


### PR DESCRIPTION
The address of the flash read was not considering the header offset.