### PR TITLE
Add the link to the service description

### DIFF
--- a/source/app_service/networking/ble/gatt_service/BatteryService.h
+++ b/source/app_service/networking/ble/gatt_service/BatteryService.h
@@ -39,8 +39,8 @@
 
 /// Setup the battery service
 ///
-/// The required fields are specified in
-/// https://confluence/display/GC/BLE+Services
+/// The service is specified in
+/// https://github.com/Sensirion/ble-services/blob/main/ble-services.yml
 void BatteryService_Create();
 
 /// Set the actual battery level

--- a/source/app_service/networking/ble/gatt_service/DataLoggerService.h
+++ b/source/app_service/networking/ble/gatt_service/DataLoggerService.h
@@ -44,8 +44,8 @@
 #define TX_FRAME_SIZE 20
 
 /// Setup the data logger service
-/// The required fields are specified in
-/// https://github.com/Sensirion/arduino-ble-gadget/blob/master/documents/Sensirion_BLE_communication_protocol.pdf
+/// The service is specified in
+/// https://github.com/Sensirion/ble-services/blob/main/ble-services.yml
 void DataLoggerService_Create();
 
 /// Write the new value of the dataLogging interval to the characteristic.

--- a/source/app_service/networking/ble/gatt_service/DeviceInfo.h
+++ b/source/app_service/networking/ble/gatt_service/DeviceInfo.h
@@ -39,11 +39,9 @@
 
 #include <stdint.h>
 
-/// Setup the device information service
-/// The required fields are specified in
-/// https://github.com/Sensirion/arduino-ble-gadget/blob/master/documents/Sensirion_BLE_communication_protocol.pdf
-/// In addition to this, the reboot request is added to the device information
-/// service. This is required to trigger the Over The Air update.
+/// Setup the device information service.
+/// The service is specified in
+/// https://github.com/Sensirion/ble-services/blob/main/ble-services.yml
 void DeviceInfo_Create();
 
 #endif  // DEVICE_INFO_H

--- a/source/app_service/networking/ble/gatt_service/DeviceSettingsService.h
+++ b/source/app_service/networking/ble/gatt_service/DeviceSettingsService.h
@@ -40,7 +40,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-/// Setup the device settings service
+/// Setup the device settings service.
 /// The required fields are specified in
 /// https://github.com/Sensirion/ble-services/blob/main/ble-services.yml
 void DeviceSettingsService_Create();

--- a/source/app_service/networking/ble/gatt_service/HumidityService.h
+++ b/source/app_service/networking/ble/gatt_service/HumidityService.h
@@ -38,7 +38,7 @@
 /// Setup the humidity service
 ///
 /// The required fields are specified in
-/// https://confluence/display/GC/BLE+Services
+/// https://github.com/Sensirion/ble-services/blob/main/ble-services.yml
 void HumidityService_Create();
 
 /// Set the actual measured humidity

--- a/source/app_service/networking/ble/gatt_service/Reboot.h
+++ b/source/app_service/networking/ble/gatt_service/Reboot.h
@@ -40,6 +40,8 @@
 /// The reboot service contains one single characteristic, the
 /// *RebootCharacteristic*. This characteristic is used to trigger
 /// a reboot or an OTA firmware update.
+/// The service is specified in
+/// https://github.com/Sensirion/ble-services/blob/main/ble-services.yml
 void Reboot_Create();
 
 #endif  // REBOOT_H

--- a/source/app_service/networking/ble/gatt_service/ShtService.h
+++ b/source/app_service/networking/ble/gatt_service/ShtService.h
@@ -42,8 +42,8 @@
 
 /// Setup the sht service
 ///
-/// The required fields are specified in
-/// https://confluence/display/GC/BLE+Services
+/// The service is specified in
+/// https://github.com/Sensirion/ble-services/blob/main/ble-services.yml
 void ShtService_Create();
 
 /// Set the serial number of the sht sensor

--- a/source/app_service/networking/ble/gatt_service/TemperatureService.h
+++ b/source/app_service/networking/ble/gatt_service/TemperatureService.h
@@ -37,8 +37,8 @@
 
 /// Setup the temperature service
 ///
-/// The required fields are specified in
-/// https://confluence/display/GC/BLE+Services
+/// The service is specified in
+/// https://github.com/Sensirion/ble-services/blob/main/ble-services.yml
 void TemperatureService_Create();
 
 /// Set the actual measured temperature


### PR DESCRIPTION
For each gatt service the link to the service description yml is added.