### PR TITLE
Show CMOSens symbol on the screen

### DIFF
--- a/source/app/Presentation.c
+++ b/source/app/Presentation.c
@@ -404,6 +404,7 @@ static void DisplayNormalOperationScreen(
   // battery symbol, this will just redraw the last active value
   Screen_DisplayLowBattery(_controller.lowBatterySymbolOn);
   Screen_DisplayBluetoothSymbol(_controller.bleOn);
+  Screen_DisplayCmoSens(true);
 
   Screen_UpdatePendingRequests();
 }

--- a/source/app_service/screen/Screen.c
+++ b/source/app_service/screen/Screen.c
@@ -361,6 +361,11 @@ void Screen_DisplayBluetoothSymbol(bool on) {
                 (on << LCD_SEG22_SHIFT));
 }
 
+void Screen_DisplayCmoSens(bool on) {
+  HAL_LCD_Write(&gLcd, LCD_COM_2_0, ~(1U << LCD_SEG22_SHIFT),
+                (on << LCD_SEG22_SHIFT));
+}
+
 void Screen_DisplayLowBattery(bool on) {
   HAL_LCD_Write(&gLcd, LCD_COM_0_0, ~(1U << LCD_SEG13_SHIFT),
                 (uint32_t)on << LCD_SEG13_SHIFT);

--- a/source/app_service/screen/Screen.h
+++ b/source/app_service/screen/Screen.h
@@ -255,6 +255,12 @@ void Screen_DisplayPoint7(bool on);
 ///           shall be switched on or off.
 void Screen_DisplayLowBattery(bool on);
 
+/// Display the CMOSens symbol on the screen.
+///
+/// @param on Flag to indicate if the CMOSens symbol
+///           shall be switched on or off.
+void Screen_DisplayCmoSens(bool on);
+
 /// Displays at most four digits from the supplied integer value.
 ///
 /// @param value An integer value that shall be displayed.


### PR DESCRIPTION
The CMOSens symbol was not displayed due to a HW bug in previous HW. Now it is working.