### PR TITLE
Delete logged samples on POR

### DIFF
--- a/source/app/System.c
+++ b/source/app/System.c
@@ -75,6 +75,9 @@
 #include "utility/scheduler/MessageId.h"
 #include "utility/scheduler/Scheduler.h"
 
+/// Flag to check if the system comes from a POR
+static bool powerOnReset;
+
 /// Type definition for the message broker initialization
 typedef struct _tMessageBus {
   MessageBroker_Broker_t broker;  ///< the message broker to be initialized
@@ -116,6 +119,7 @@ static MessageBus_t _bleMessageBroker = {
     .priority = SCHEDULER_PRIO_0};
 
 void System_Init(void) {
+  powerOnReset = Clock_ReadAndClearPorActiveFlag();
   // Setup the message passing infrastructure.
   // This is the first thing to do since errors are also propagated as
   // messages
@@ -168,7 +172,8 @@ static void RunSystem(void) {
 
   Message_Message_t peripheralInitialized = {
       .header.category = MESSAGE_BROKER_CATEGORY_SYSTEM_STATE_CHANGE,
-      .header.id = MESSAGE_ID_PERIPHERALS_INITIALIZED};
+      .header.id = MESSAGE_ID_PERIPHERALS_INITIALIZED,
+      .header.parameter1 = powerOnReset};
   Message_PublishAppMessage(&peripheralInitialized);
 
   while (1) {

--- a/source/hal/Clock.c
+++ b/source/hal/Clock.c
@@ -38,6 +38,7 @@
 #include "Clock.h"
 
 #include "stm32wbxx_hal.h"
+#include "stm32wbxx_ll_rcc.h"
 #include "utility/ErrorHandler.h"
 
 /// Initialize and configure the  peripheral clocks
@@ -130,4 +131,10 @@ static void ResetRtcBackupDomain() {
     __HAL_RCC_BACKUPRESET_FORCE();
     __HAL_RCC_BACKUPRESET_RELEASE();
   }
+}
+
+bool Clock_ReadAndClearPorActiveFlag() {
+  bool por = LL_RCC_IsActiveFlag_BORRST();
+  LL_RCC_ClearResetFlags();
+  return por;
 }

--- a/source/hal/Clock.h
+++ b/source/hal/Clock.h
@@ -39,6 +39,7 @@
 #ifndef CLOCK_H
 #define CLOCK_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 /// Initialize and configure the all relevant clocks
@@ -50,5 +51,14 @@
 /// initialized.
 /// @param hseTuning tuning value for the HSE oscillator
 void Clock_ConfigureSystemAndPeripheralClocks(uint8_t hseTuning);
+
+/// Read the power on reset flag and clear the reset flags afterwards.
+///
+/// We want to distinguish between a soft reset and a reset caused by low
+/// voltage. The soft reset is considered to be very fast and it will not
+/// break the time sequence of the logged samples.
+/// A brown oo
+/// @return true if the POR was active; false otherwise.
+bool Clock_ReadAndClearPorActiveFlag();
 
 #endif  // CONFIGURE_CLOCK_H


### PR DESCRIPTION
The measurement item log does not contain time information. Hence we do not know how long the system is powered off when the battery is removed and the interval between subsequently logged items may be considerable different from the logging interval.
In order to avoid this situation all samples are removed on a POR. A soft reset will not delete the available data points. Deleting the flash is the easier solotion than just invalidating some pages. This would require modification of the existing logic.