### PR TITLE
Fix item store enumerator

### DIFF
--- a/source/app_service/item_store/ItemStore.c
+++ b/source/app_service/item_store/ItemStore.c
@@ -431,6 +431,8 @@ static bool InitEnumeratorStatus(uint8_t page_nr,
                                  uint16_t startIndex) {
   EnumeratorStatus_t* status = &itemStore->enumeratorStatus;
   status->currentIndex = startIndex;  // current read index on this page
+  // read the page header to check if the page is valid and initialize
+  // the page id from it!
   if (!Flash_Read(PAGE_ADDR(page_nr), (uint8_t*)&status->enumeratingPage,
                   sizeof(PageHeader_t))) {
     return false;
@@ -440,7 +442,7 @@ static bool InitEnumeratorStatus(uint8_t page_nr,
   }
   // we are reading how many items are on the page that we enumerate
   if (page_nr == itemStore->nextWritePageInfo.pageId) {
-    // this is the page where new items are inserted
+    // this is the actual page where new items are inserted!
     status->itemsOnPage = itemStore->currentPageNrOfItems;
   } else {
     // this is a full page
@@ -487,7 +489,8 @@ static bool FindEnumeratorStartPosition(ItemStoreInfo_t* itemStore,
   if (skipping > 0) {
     return false;
   }
-  *startPage = itemStore->enumeratorStatus.enumeratingPage.beginTag.pageId;
+
+  *startPage = page_nr;
   *startPosition = itemsOnPage + skipping;
   return true;
 }

--- a/source/app_service/item_store/MeasurementItemController.c
+++ b/source/app_service/item_store/MeasurementItemController.c
@@ -357,11 +357,11 @@ static void BeginReadSamples(bool enumeratorReady) {
       .head.parameter1 = SERVICE_REQUEST_MESSAGE_ID_SET_REQUESTED_SAMPLES,
       .parameter.responsePtr = 0};
 
-  if (!enumeratorReady) {
-    ErrorHandler_RecoverableError(ERROR_CODE_ITEM_STORE);
-    return;
+  // in case of an empty log we play the same sequence but with no samples
+  uint16_t availableSamples = 0;
+  if (enumeratorReady) {
+    availableSamples = ItemStore_Count(&_sampleEnumerator) * 2;
   }
-  uint16_t availableSamples = ItemStore_Count(&_sampleEnumerator) * 2;
   ItemStore_EndEnumerate(&_sampleEnumerator);
   _sampleRequest.metadata.numberOfSamples =
       MIN(availableSamples, _sampleRequest.requestedNrOfSamples);


### PR DESCRIPTION
In case an enumerator was opened on an empty item store a page id of 0xFF was assigned which caused a hardfault.