### PR TITLE
Fix hardfault when compiling with O2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ add_link_options(
 # Build type
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "release")
     message(STATUS "Optimization for release build")
-    add_compile_options(-O0)
+    add_compile_options(-O2)
 else ()
     message(STATUS "No optimization for debug build")
     add_compile_options(-O0 -g)

--- a/lib/shared/include/utilities_conf.h
+++ b/lib/shared/include/utilities_conf.h
@@ -55,7 +55,7 @@ extern "C" {
 #define UTIL_SEQ_ENTER_CRITICAL_SECTION( )      UTILS_ENTER_CRITICAL_SECTION( )
 #define UTIL_SEQ_EXIT_CRITICAL_SECTION( )       UTILS_EXIT_CRITICAL_SECTION( )
 #define UTIL_SEQ_CONF_TASK_NBR                  (32)
-#define UTIL_SEQ_CONF_PRIO_NBR                  (2)
+#define UTIL_SEQ_CONF_PRIO_NBR                  (3)
 #define UTIL_SEQ_MEMSET8( dest, value, size )   UTILS_MEMSET8( dest, value, size )
 
 #ifdef __cplusplus

--- a/source/hal/Flash.c
+++ b/source/hal/Flash.c
@@ -115,7 +115,7 @@ void Flash_Init() {
   // initialize and register flash FSM
   MessageBroker_Create(&_flashMessageDispatcher, _flash_task_messages,
                        NR_OF_FLASH_MESSAGES,
-                       SCHEDULER_TASK_HANDLE_FLASH_OPERATION, SCHEDULER_PRIO_3);
+                       SCHEDULER_TASK_HANDLE_FLASH_OPERATION, SCHEDULER_PRIO_2);
   MessageBroker_RegisterListener(&_flashMessageDispatcher,
                                  &_flashMessageHandler);
   UTIL_SEQ_RegTask(_flashMessageDispatcher.taskBitmap, UTIL_SEQ_RFU, FlashTask);

--- a/source/utility/scheduler/Scheduler.h
+++ b/source/utility/scheduler/Scheduler.h
@@ -60,12 +60,12 @@ typedef enum {
 } Scheduler_NoHciCmdTaskId_t;
 
 /// This enum describes all the available priorities
-/// SCHEDULER_PRIO_0 is the highest priority
+/// SCHEDULER_PRIO_0 is the highest priority;
+/// Only three priorities are allowed!
 typedef enum {
   SCHEDULER_PRIO_0,
   SCHEDULER_PRIO_1,
   SCHEDULER_PRIO_2,
-  SCHEDULER_PRIO_3,
 } Scheduler_SchedulerPriority_t;
 
 /// This enum describes the list sequencer events


### PR DESCRIPTION
The hardfault that occurred when compiling with optimization level O2 was caused by writing over the array boundaries of the TaskPrio array of the scheduler.

# Checklist for Pull Requests
- [x] Manual testing of new feature on hardware target.

[^1]: according to [Keep A Changelog](https://keepachangelog.com/en/1.1.0/) rules.
[^2]: BLE services documentation [Github repository](https://github.com/Sensirion/ble-services).
