### PR TITLE
Fix application up time in ble context

### DIFF
--- a/source/app/BleContext.c
+++ b/source/app/BleContext.c
@@ -516,7 +516,6 @@ static bool BleDefaultStateCb(Message_Message_t* message) {
 static bool BleDisabledStateCb(Message_Message_t* message) {
   if (message->header.category == MESSAGE_BROKER_CATEGORY_BUTTON_EVENT &&
       message->header.id == BUTTON_EVENT_LONG_PRESS) {
-    gBleApplicationContext.timeRunningTick = 0;
     BleTypes_AdvertisementMode_t advSpec = {
         .advertiseModeSpecification.connectable = true,
         .advertiseModeSpecification.interval = ADVERTISEMENT_INTERVAL_SHORT};
@@ -536,7 +535,9 @@ static bool BleDisabledStateCb(Message_Message_t* message) {
 static bool ForwardToBleAppCb(Message_Message_t* message) {
   if (message->header.category == MESSAGE_BROKER_CATEGORY_TIME_INFORMATION &&
       message->header.id == MESSAGE_ID_TIME_INFO_TIME_ELAPSED) {
-    BleInterface_PublishBleMessage(message);
+    // no need to forward the message as it is only used to update
+    // the time running variable
+    gBleApplicationContext.timeRunningSeconds = message->parameter2;
     return true;
   }
 
@@ -549,7 +550,7 @@ static bool ForwardToBleAppCb(Message_Message_t* message) {
   if (message->header.category == MESSAGE_BROKER_CATEGORY_BUTTON_EVENT &&
       message->header.id == BUTTON_EVENT_LONG_PRESS) {
     // do not react on long press during bootup
-    if (gBleApplicationContext.timeRunningTick < 5) {
+    if (gBleApplicationContext.timeRunningSeconds < 5) {
       return false;
     }
     BleInterface_PublishBleMessage(message);

--- a/source/app_service/networking/ble/BleTypes.h
+++ b/source/app_service/networking/ble/BleTypes.h
@@ -190,7 +190,7 @@ typedef struct {
   BleTypes_GlobalContext_t bleApplicationContextLegacy;
   /// Connection Status
   BleTypes_ConnStatus_t deviceConnectionStatus;
-  uint64_t timeRunningTick;       ///< the time the ble app is running
+  uint64_t timeRunningSeconds;    ///< the time the app is running
   void* advertisementData;        ///< advertisement data
   uint8_t advertisementDataSize;  ///< size of advertisement
   uint8_t* localName;             ///< Pointer to the device name


### PR DESCRIPTION
The ble context needs to know the time the application is running in order to handle the button press properly.
