### PR TITLE
Include device-id in alernative name

### DIFF
--- a/source/app_service/item_store/SettingsController.c
+++ b/source/app_service/item_store/SettingsController.c
@@ -111,9 +111,10 @@ static bool DefaultStateCB(Message_Message_t* message) {
   if (message->header.category == MESSAGE_BROKER_CATEGORY_SYSTEM_STATE_CHANGE) {
     if (message->header.id == MESSAGE_ID_PERIPHERALS_INITIALIZED) {
       // make sure that the proper device name is used
-      strncpy(_defaultSettings.deviceName, ProductionParameters_GetDeviceName(),
-              DEVICE_NAME_MAX_LEN);
-
+      uint32_t deviceId = ProductionParameters_GetUniqueDeviceId() & 0xFFFF;
+      snprintf(_defaultSettings.deviceName, DEVICE_NAME_BUFFER_LENGTH,
+               "%s %02lx%c%02lx", ProductionParameters_GetDeviceName(),
+               (deviceId >> 8), ':', (deviceId & 0xFF));
       ItemStore_BeginEnumerate(ITEM_DEF_SYSTEM_CONFIG, &_settingsEnumerator,
                                InitializeSettings);
       return true;


### PR DESCRIPTION
In order to be able to distinguish several devices from the alternative name before this name was set by a user, a default shall be used the is unique.
Therefore we add the device id to the former default name.

# Checklist for Pull Requests
- [x] Manual testing of new feature on hardware target.
