### PR TITLE
Support debug pins PA12 and PB11

### DIFF
--- a/source/hal/Gpio.c
+++ b/source/hal/Gpio.c
@@ -92,6 +92,27 @@ bool Gpio_IsPc10Set() {
   return HAL_GPIO_ReadPin(UserButton_GPIO_Port, UserButton_Pin) == GPIO_PIN_SET;
 }
 
+void Gpio_EnableDebugPins() {
+  GPIO_InitTypeDef gpioConfig = {0};
+  gpioConfig.Pin = DEBUG_PIN_PB11;
+  gpioConfig.Mode = GPIO_MODE_OUTPUT_PP;
+  gpioConfig.Pull = GPIO_NOPULL;
+  HAL_GPIO_Init(GPIOB, &gpioConfig);
+  HAL_GPIO_WritePin(GPIOB, DEBUG_PIN_PB11, GPIO_PIN_RESET);
+
+  gpioConfig.Pin = DEBUG_PIN_PA12;
+  HAL_GPIO_Init(GPIOA, &gpioConfig);
+  HAL_GPIO_WritePin(GPIOA, DEBUG_PIN_PA12, GPIO_PIN_RESET);
+}
+
+void Gpio_SetDebugPinB11(bool value) {
+  HAL_GPIO_WritePin(GPIOB, DEBUG_PIN_PB11, (GPIO_PinState)value);
+}
+
+void Gpio_SetDebugPinA12(bool value) {
+  HAL_GPIO_WritePin(GPIOA, DEBUG_PIN_PA12, (GPIO_PinState)value);
+}
+
 /// Interrupt handler for external gpio interrupt
 /// overrides weak definition name must not be changed
 void EXTI15_10_IRQHandler() {

--- a/source/hal/Gpio.h
+++ b/source/hal/Gpio.h
@@ -46,6 +46,13 @@
 /// Alias for GPIO PC10
 #define UserButton_Pin GPIO_PIN_10
 
+/// Enumeration to refer to the debug pins of the demo board.
+/// These pins are externally available and can be attached to a logic analyzer.
+typedef enum {
+  DEBUG_PIN_PB11 = GPIO_PIN_11,
+  DEBUG_PIN_PA12 = GPIO_PIN_12,
+} DEBUG_PIN;
+
 /// type definition of signal handler callback
 typedef void (*Gpio_HandleGpioExtiSignalCb_t)();
 
@@ -64,5 +71,18 @@ void Gpio_UnregisterOnExtiSignalPc10();
 /// Query the status of Gpio pin 10 of port c
 /// @return true if the pin is high; false otherwise.
 bool Gpio_IsPc10Set();
+
+/// Enable debug pins
+///
+/// The pins are enabled and configured as output.
+void Gpio_EnableDebugPins();
+
+/// Set the value of the selected debug pin port B-11.
+/// @param value The value to be set
+void Gpio_SetDebugPinB11(bool value);
+
+/// Set the value of the selected debug pin port A-12.
+/// @param value The value to be set
+void Gpio_SetDebugPinA12(bool value);
 
 #endif  // GPIO_H


### PR DESCRIPTION
In order to optimize and debug the Demo-board firmware we need to be able to non intrusively observe the application.
For this purpose two pins are made available on the demo board connector.
With the new functionality these pins can be configured as output and forced to a desired state. In this way the code can be instrumented according to the debug or measurement scenario.

# Checklist for Pull Requests

- [~] \(Mandatory) New header files have Doxygen tag @file (placed between include guard and #includes).
- [~] \(Mandatory) New source/header files have license header.
- [~] Update Doxygen peripherals documentation.
- [~] Update changelog[^1].
- [~] If new BLE characteristics are added, update the documentation[^2].
- [x] Manual testing of new feature on hardware target.


[^1]: according to [Keep A Changelog](https://keepachangelog.com/en/1.1.0/) rules.
[^2]: BLE services documentation [Github repository](https://github.com/Sensirion/ble-services).
