### PR TITLE
Fix log macros

### DIFF
--- a/source/utility/log/Log.h
+++ b/source/utility/log/Log.h
@@ -48,7 +48,7 @@
 /// write a debug message to trace output
 #define LOG_DEBUG(message, ...)                                            \
   snprintf(Trace_GetMessageFormatBuffer(), TRACE_FMT_BUFFER_SIZE, message, \
-           __VA_ARGS__);                                                   \
+           ##__VA_ARGS__);                                                 \
   Trace_Message("Debug: %s\n", Trace_GetMessageFormatBuffer())
 
 #else
@@ -72,13 +72,13 @@
 /// write a error message to trace output
 #define LOG_ERROR(message, ...)                                            \
   snprintf(Trace_GetMessageFormatBuffer(), TRACE_FMT_BUFFER_SIZE, message, \
-           __VA_ARGS__);                                                   \
+           ##__VA_ARGS__);                                                 \
   Trace_Message("Error: %s\n", Trace_GetMessageFormatBuffer())
 
 /// write a info message to trace output
 #define LOG_INFO(message, ...)                                             \
   snprintf(Trace_GetMessageFormatBuffer(), TRACE_FMT_BUFFER_SIZE, message, \
-           __VA_ARGS__);                                                   \
+           ##__VA_ARGS__);                                                 \
   Trace_Message("Info: %s\n", Trace_GetMessageFormatBuffer())
 #endif  // STATIC_CODE_ANALYSIS
 


### PR DESCRIPTION
In order to consistently replace all occorrencies of TraceMessage(..) with a log macro, the log macro has to be corrected. We want to be abel to write LOG_INFO("message") which was not possible with the versio as it was before. With this little fix, the macros can be used with one or more arguments.

# Checklist for Pull Requests

- [~] \(Mandatory) New header files have Doxygen tag @file (placed between include guard and #includes).
- [~] \(Mandatory) New source/header files have license header.
- [~] Update Doxygen peripherals documentation.
- [~] Update changelog[^1].
- [~] If new BLE characteristics are added, update the documentation[^2].
- [x] Manual testing of new feature on hardware target.

[^1]: according to [Keep A Changelog](https://keepachangelog.com/en/1.1.0/) rules.
[^2]: BLE services documentation [Github repository](https://github.com/Sensirion/ble-services).
