### PR TITLE
Restrict MTU to 64 bytes

### DIFF
--- a/lib/shared/include/app_conf.h
+++ b/lib/shared/include/app_conf.h
@@ -220,7 +220,7 @@
  * Maximum supported ATT_MTU size
  * This parameter is ignored by the CPU2 when CFG_BLE_OPTIONS has SHCI_C2_BLE_INIT_OPTIONS_LL_ONLY flag set
  */
-#define CFG_BLE_MAX_ATT_MTU             (156)
+#define CFG_BLE_MAX_ATT_MTU             (64)
 
 /**
  * Size of the storage area for Attribute values
@@ -740,4 +740,3 @@ typedef enum
 #define CFG_OTP_END_ADRESS      OTP_AREA_END_ADDR
 
 #endif /*APP_CONF_H */
-


### PR DESCRIPTION
The data download does not run stable with the previous MTU of 154 bytes.

# Checklist for Pull Requests

- [~] \(Mandatory) New header files have Doxygen tag @file (placed between include guard and #includes).
- [~] \(Mandatory) New source/header files have license header.
- [~] Update Doxygen peripherals documentation.
- [~] Update changelog[^1].
- [~] If new BLE characteristics are added, update the documentation[^2].
- [x] Manual testing of new feature on hardware target.

[^1]: according to [Keep A Changelog](https://keepachangelog.com/en/1.1.0/) rules.
[^2]: BLE services documentation [Github repository](https://github.com/Sensirion/ble-services).
