### PR TITLE
Distinguish development versions in MyAmbience

### DIFF
--- a/source/app_service/networking/ble/gatt_service/DeviceInfo.c
+++ b/source/app_service/networking/ble/gatt_service/DeviceInfo.c
@@ -45,6 +45,14 @@
 #include "tl.h"
 #include "utility/ErrorHandler.h"
 
+#if defined(DEBUG)
+/// Used suffix of firmware version
+#define VERSION_SUFFIX "-dev.d"
+#else
+/// Used suffix of firmware version
+#define VERSION_SUFFIX "-dev.r"
+#endif
+
 /// structure to hold the handles for gatt service and its characteristics
 PLACE_IN_SECTION("BLE_DRIVER_CONTEXT") static struct _tService {
   uint16_t serviceHandle;               ///< service handle
@@ -151,8 +159,15 @@ static void AddFirmwareVersionCharacteristic(struct _tService* service) {
       .encryptionKeySize = 10,
       .isVariableLengthValue = true};
 
-  snprintf((char*)buffer, sizeof(buffer), "%i.%i.%i", FIRMWARE_VERSION_MAJOR,
-           FIRMWARE_VERSION_MINOR, FIRMWARE_VERSION_PATCH);
+  if (FIRMWARE_VERSION_DEVELOP) {
+    snprintf((char*)buffer, sizeof(buffer), "%i.%i.%i" VERSION_SUFFIX,
+             FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR,
+             FIRMWARE_VERSION_PATCH);
+
+  } else {
+    snprintf((char*)buffer, sizeof(buffer), "%i.%i.%i", FIRMWARE_VERSION_MAJOR,
+             FIRMWARE_VERSION_MINOR, FIRMWARE_VERSION_PATCH);
+  }
   uint8_t length = strnlen((char*)buffer, sizeof(buffer));
   service->firmwareVersionHandle = BleGatt_AddCharacteristic(
       service->serviceHandle, &characteristic, buffer, length);


### PR DESCRIPTION
We want to be able to distinguish develop versions from release versions and even if a develop version is a release build or a debug build.

# Checklist for Pull Requests

- [x ] Manual testing of new feature on hardware target.


# Checklist before Releases

- [ ] \(Mandatory) Update changelog[^1].
- [ ] \(Mandatory) Manual testing of the release build.
- [ ] Update internal release Confluence page on project space.


[^1]: according to [Keep A Changelog](https://keepachangelog.com/en/1.1.0/) rules.
[^2]: BLE services documentation [Github repository](https://github.com/Sensirion/ble-services).
