### PR TITLE
Show error code in case we get unexpected behavior

### DIFF
--- a/source/utility/ErrorHandler.h
+++ b/source/utility/ErrorHandler.h
@@ -58,6 +58,8 @@ typedef enum {
   ERROR_CODE_SENSOR_READOUT,
   ERROR_CODE_BLE,
   ERROR_CODE_ITEM_STORE,
+  ERROR_CODE_CM0_NOT_READY,
+  ERROR_CODE_BLE_FW_NOT_RUNNING,
 } ErrorHandler_ErrorCode_t;
 
 /// Signals an unrecoverable error to the application


### PR DESCRIPTION
In case we do receive an error from the cortex M0 or no BLE firmware is running, we want to see an error code.

# Checklist for Pull Requests

- [x] Manual testing of new feature on hardware target.
