### PR TITLE
Prevent hiding BLE symbol if BLE is still on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ the full log, please refer to the git commit history.
 
 ## Unreleased
 
+### Fixed
+
+* Check return status of aci_gap_set_non_discoverable() before changing
+  display with ble-symbol
+
+### Changed
+
+* Add new error codes to allow for better error diagnostics during boot up.
+
 ## 1.0.0 (2025-03-27)
 
 ### Fixed

--- a/source/app/BleContext.c
+++ b/source/app/BleContext.c
@@ -812,17 +812,21 @@ static void UpdateDeviceSettingCharacteristics(Message_Message_t* message) {
 
 static void SwitchBleOff() {
   BleGap_AdvertiseCancel(&gBleApplicationContext);
-  // we still need to receive button events (the user might want to
-  // turn the radio on again) and battery events in order to keep track
-  // of the application state
-  _bleBridge.receiveMask = MESSAGE_BROKER_CATEGORY_BUTTON_EVENT |
-                           MESSAGE_BROKER_CATEGORY_BATTERY_EVENT;
-  _bleAppListener.currentMessageHandlerCb = BleDisabledStateCb;
+  // in case the cancel request was successful we change the
+  // application state
+  if (gBleApplicationContext.deviceConnectionStatus == BLE_INTERFACE_IDLE) {
+    // we still need to receive button events (the user might want to
+    // turn the radio on again) and battery events in order to keep track
+    // of the application state
+    _bleBridge.receiveMask = MESSAGE_BROKER_CATEGORY_BUTTON_EVENT |
+                             MESSAGE_BROKER_CATEGORY_BATTERY_EVENT;
+    _bleAppListener.currentMessageHandlerCb = BleDisabledStateCb;
 
-  // publish the information in the application
-  Message_Message_t msg = {
-      .header.category = MESSAGE_BROKER_CATEGORY_SYSTEM_STATE_CHANGE,
-      .header.id = MESSAGE_ID_BLE_SUBSYSTEM_OFF,
-  };
-  Message_PublishAppMessage(&msg);
+    // publish the information in the application
+    Message_Message_t msg = {
+        .header.category = MESSAGE_BROKER_CATEGORY_SYSTEM_STATE_CHANGE,
+        .header.id = MESSAGE_ID_BLE_SUBSYSTEM_OFF,
+    };
+    Message_PublishAppMessage(&msg);
+  }
 }

--- a/source/app_service/networking/ble/BleGap.c
+++ b/source/app_service/networking/ble/BleGap.c
@@ -187,9 +187,12 @@ void BleGap_AdvertiseCancel(BleTypes_ApplicationContext_t* applicationContext) {
   if (applicationContext->deviceConnectionStatus !=
       BLE_INTERFACE_CONNECTED_SERVER) {
     tBleStatus ret = BLE_STATUS_INVALID_PARAMS;
-    UNUSED(ret);
     ret = aci_gap_set_non_discoverable();
-    applicationContext->deviceConnectionStatus = BLE_INTERFACE_IDLE;
+    if (ret == BLE_STATUS_SUCCESS) {
+      applicationContext->deviceConnectionStatus = BLE_INTERFACE_IDLE;
+      applicationContext->currentAdvertisementMode.advertiseModeSpecification
+          .connectable = false;
+    }
     LOG_DEBUG_CALLSTATUS("aci_gap_set_non_discoverable()", ret);
   }
   // NOLINTEND(clang-analyzer-deadcode.DeadStores)


### PR DESCRIPTION
An error was reported that the demo-board was advertizing but not showing the BLE symbol. I could not reproduce this problem. But the only way this could happen seems to be the case when we want stop advertizing but the request fails.

# Checklist for Pull Requests

- [x] Manual testing of new feature on hardware target.

