### PR TITLE
Prevent recovering from critical battery level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ the full log, please refer to the git commit history.
 
 * Check return status of aci_gap_set_non_discoverable() before changing
   display with ble-symbol
+* Prevent recover from application state `critical battery level`
 
 ### Changed
 

--- a/source/app/BleContext.c
+++ b/source/app/BleContext.c
@@ -625,6 +625,18 @@ static bool ForwardToBleAppCb(Message_Message_t* message) {
   if (message->header.category == MESSAGE_BROKER_CATEGORY_BATTERY_EVENT) {
     if (message->header.id == BATTERY_MONITOR_MESSAGE_ID_STATE_CHANGE) {
       BatteryMonitor_Message_t* batteryMsg = (BatteryMonitor_Message_t*)message;
+      if (gBleApplicationContext.currentApplicationState ==
+          BATTERY_MONITOR_APP_STATE_CRITICAL_BATTERY_LEVEL) {
+        // We do not recover from critical battery level! Once the battery level was critical,
+        // the battery should be changed or we do not do any further BLE operation.
+        // On one hand we enable the charge pump of the display. This will consume more power
+        // and this additional power consumption is not revertible.
+        // On the other hand we start the battery symbol blinking which is not stopped anymore.
+        // Last but not least we have to assume that the inner resistor of the battery is already
+        // significant and further BLE operation may corrupt the device and prevent it from
+        // booting without flashing again.
+        return true;
+      }
       gBleApplicationContext.currentApplicationState = batteryMsg->currentState;
       // switch the radio off in case the battery is low and the user did
       // not yet decide to use it anyway


### PR DESCRIPTION
Havy loads on the battery such as download of large amount of logging data may dramatically reduce the current voltage of the battery. The less capacity the battery has, the more severe the voltage drop will be.
As long as the voltage is above a critical level we allow the application to recover and to adjust the application state when the battery recovers.
But when the voltage drops below 2.5V we do not change the application state anymore but assume that the battery needs to be changed and the device needs to be reset.

# Checklist for Pull Requests

- [x] Manual testing of new feature on hardware target.
